### PR TITLE
Add fullscreen startup and configurable zoom

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,0 +1,5 @@
+{
+  "initial_zoom": 1.0,
+  "tile_count": 200,
+  "max_zoom": 2.5
+}


### PR DESCRIPTION
## Summary
- start the game in fullscreen mode with an escape key exit helper
- add a JSON configuration file for tile count and zoom defaults that the game loads on startup
- support zooming via mouse wheel/keys and render semi-transparent inventory slots

## Testing
- python -m compileall survivor_game.py

------
https://chatgpt.com/codex/tasks/task_e_68e141082a68832193dc35445c3b0a0d