### PR TITLE
Align player facing with mouse and directional speed

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,6 +5,7 @@
   "player": {
     "max_health": 100,
     "initial_health": 100,
-    "max_speed": 1.2
+    "max_speed": 1.2,
+    "initial_speed": 1.2
   }
 }


### PR DESCRIPTION
## Summary
- make the survivor always face the mouse cursor and compute movement speed based on the angle between input and facing direction
- add mouse tracking helpers so camera dragging keeps the facing updated
- expose a configurable initial_speed value in the player config

## Testing
- python -m compileall survivor_game.py

------
https://chatgpt.com/codex/tasks/task_e_68e149c56f8483219859167c2d1632b4