### PR TITLE
Implement XP-based enemy waves and optimize map rendering

### DIFF
--- a/Level.json
+++ b/Level.json
@@ -1,0 +1,28 @@
+{
+  "levels": [
+    {
+      "min_xp": 0,
+      "max_xp": 99,
+      "spawns": [
+        {"enemy": "zombie", "interval_seconds": 30}
+      ]
+    },
+    {
+      "min_xp": 100,
+      "max_xp": 200,
+      "spawns": [
+        {"enemy": "zombie", "interval_seconds": 30},
+        {"enemy": "skeleton", "interval_seconds": 30}
+      ]
+    },
+    {
+      "min_xp": 201,
+      "max_xp": null,
+      "spawns": [
+        {"enemy": "zombie", "interval_seconds": 25},
+        {"enemy": "skeleton", "interval_seconds": 20},
+        {"enemy": "ogre", "interval_seconds": 45}
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- simplify tile rendering by reusing canvas rectangles so the map draws faster again
- load enemy and level configuration from JSON files and schedule spawns based on XP ranges
- add moving enemies that damage the player on contact and render simple health indicators

## Testing
- python -m compileall survivor_game.py

------
https://chatgpt.com/codex/tasks/task_e_68e14e971910832191e0c8a6ed70d0e9